### PR TITLE
Change D3DXVECTOR3/D3DXVECTOR2 to Float3/Float2

### DIFF
--- a/src/AnmManager.cpp
+++ b/src/AnmManager.cpp
@@ -321,11 +321,11 @@ ZunBool AnmManager::ExecuteScript(AnmVm *vm)
         case AnmOpcode_Pos:
             if (!vm->prefix.usePosOffset)
             {
-                vm->pos = D3DXVECTOR3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
+                vm->pos = Float3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
             }
             else
             {
-                vm->pos2 = D3DXVECTOR3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
+                vm->pos2 = Float3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
             }
             break;
         case AnmOpcode_PosTimeDecel2:
@@ -346,7 +346,7 @@ ZunBool AnmManager::ExecuteScript(AnmVm *vm)
                 vm->posInitial = vm->pos2;
             }
 
-            vm->posFinal = D3DXVECTOR3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
+            vm->posFinal = Float3(GET_FLOAT_VAR(0), GET_FLOAT_VAR(1), GET_FLOAT_VAR(2));
 
             vm->prefix.interpEndTimers[AnmInterp_Pos] = GET_INT_VAR(3);
             vm->prefix.interpCurrentTimers[AnmInterp_Pos] = 0;

--- a/src/AnmManager.hpp
+++ b/src/AnmManager.hpp
@@ -8,7 +8,6 @@
 #include "inttypes.hpp"
 #include "utils.hpp"
 #include <d3d8.h>
-#include <d3dx8math.h>
 
 #define GAME_WINDOW_WIDTH 640
 #define GAME_WINDOW_HEIGHT 480
@@ -17,16 +16,17 @@ namespace th08
 {
 struct VertexDiffuseXyzrhw
 {
-    D3DXVECTOR3 pos;
+    Float3 pos;
     f32 w;
     D3DCOLOR diffuse;
 };
 
 struct VertexTex1DiffuseXyzrhw
 {
-    D3DXVECTOR4 pos;
+    Float3 pos;
+    float w;
     D3DCOLOR diffuse;
-    D3DXVECTOR2 textureUV;
+    Float2 textureUV;
 };
 
 // Touhou 8 uses DirectX 8.1, but evidently Zun used some mismatched DirectX 8 headers as well
@@ -249,15 +249,15 @@ struct AnmLoadedSprite
 {
     i32 anmIdx;
     IDirect3DTexture8 *texture;
-    ZunVec2 startPixelInclusive;
-    ZunVec2 endPixelInclusive;
+    Float2 startPixelInclusive;
+    Float2 endPixelInclusive;
     float height;
     float width;
-    ZunVec2 uvStart;
-    ZunVec2 uvEnd;
+    Float2 uvStart;
+    Float2 uvEnd;
     float heightPx;
     float widthPx;
-    ZunVec2 scaleFactor;
+    Float2 scaleFactor;
     u32 unk0x40;
 };
 
@@ -280,12 +280,12 @@ struct AnmRawInstr
 
 struct AnmPrefix
 {
-    D3DXVECTOR3 rotation;
-    D3DXVECTOR3 angleVel;
-    D3DXVECTOR2 scale;
-    D3DXVECTOR2 scaleGrowth;
-    D3DXVECTOR2 spriteSize;
-    D3DXVECTOR2 uvScrollPos;
+    Float3 rotation;
+    Float3 angleVel;
+    Float2 scale;
+    Float2 scaleGrowth;
+    Float2 spriteSize;
+    Float2 uvScrollPos;
     ZunTimer currentTimeInScript;
     ZunTimer waitTimer;
     ZunTimer interpCurrentTimers[AnmInterp_Last];
@@ -301,7 +301,7 @@ struct AnmPrefix
     f32 floatVar3;
     i32 counterVar0;
     i32 counterVar1;
-    D3DXVECTOR2 uvScrollVel;
+    Float2 uvScrollVel;
     D3DXMATRIX matrix1;
     D3DXMATRIX matrix2;
     D3DXMATRIX matrix3;
@@ -342,7 +342,7 @@ C_ASSERT(sizeof(AnmPrefix) == 0x208);
 struct AnmVm
 {
     AnmPrefix prefix;
-    D3DXVECTOR3 pos;
+    Float3 pos;
     i16 activeSpriteIndex;
     i16 anmFileIndex;
     i16 baseSpriteIndex;
@@ -353,18 +353,18 @@ struct AnmVm
     ZunTimer interruptReturnTime;
     AnmRawInstr *interruptReturnInstruction;
 
-    D3DXVECTOR3 posInitial;
-    D3DXVECTOR3 posFinal;
-    D3DXVECTOR3 rotateInitial;
-    D3DXVECTOR3 rotateFinal;
-    D3DXVECTOR2 scaleInitial;
-    D3DXVECTOR2 scaleFinal;
+    Float3 posInitial;
+    Float3 posFinal;
+    Float3 rotateInitial;
+    Float3 rotateFinal;
+    Float2 scaleInitial;
+    Float2 scaleFinal;
     ZunColor color1Initial;
     ZunColor color1Final;
     ZunColor color2Initial;
     ZunColor color2Final;
 
-    D3DXVECTOR3 pos2;
+    Float3 pos2;
     i32 timeOfLastSpriteSet;
     u8 fontWidth;
     u8 fontHeight;
@@ -422,8 +422,8 @@ struct AnmLoaded
     {
         vm->scriptIndex = scriptIdx;
 
-        vm->pos = D3DXVECTOR3(0, 0, 0);
-        vm->pos2 = D3DXVECTOR3(0, 0, 0);
+        vm->pos = Float3(0, 0, 0);
+        vm->pos2 = Float3(0, 0, 0);
 
         vm->fontHeight = 15;
         vm->fontWidth = 15;
@@ -660,9 +660,9 @@ struct AnmManager
     u32 scriptsExecutedThisFrame;
     u32 renderStateChangesThisFrame;
     u32 flushesThisFrame;
-    D3DXVECTOR2 screenShakeOffset;
+    Float2 screenShakeOffset;
     AnmLoaded anmFiles[256];
-    D3DXVECTOR3 unk0x1c24;
+    Float3 unk0x1c24;
     unknown_fields(0x1c30, 0x34);
     AnmVm unk0x1c64;
     unknown_fields(0x1f08, 0x130);

--- a/src/AsciiManager.cpp
+++ b/src/AsciiManager.cpp
@@ -152,7 +152,7 @@ void AsciiManager::CutChain()
 }
 
 #pragma var_order(nextString)
-void AsciiManager::AddString(D3DXVECTOR3 *position, const char *string)
+void AsciiManager::AddString(Float3 *position, const char *string)
 {
     AsciiManagerString *nextString;
 
@@ -183,7 +183,7 @@ void AsciiManager::AddString(D3DXVECTOR3 *position, const char *string)
     }
 }
 
-void AsciiManager::AddFormatText(D3DXVECTOR3 *position, const char *fmt, ...)
+void AsciiManager::AddFormatText(Float3 *position, const char *fmt, ...)
 {
     char buf[512];
     va_list va;
@@ -194,7 +194,7 @@ void AsciiManager::AddFormatText(D3DXVECTOR3 *position, const char *fmt, ...)
     va_end(va);
 }
 
-int AsciiManager::AddFormatText2(D3DXVECTOR3 *position, const char *fmt, ...)
+int AsciiManager::AddFormatText2(Float3 *position, const char *fmt, ...)
 {
     char buf[512];
     va_list args;
@@ -213,7 +213,7 @@ int AsciiManager::AddFormatText2(D3DXVECTOR3 *position, const char *fmt, ...)
 #pragma var_order(spaceWidth, i, curString, text, isGui, vector)
 void AsciiManager::OnDrawLowPrioImpl()
 {
-    D3DXVECTOR3 vector;
+    Float3 vector;
     ZunBool isGui = TRUE;
     int i;
     AsciiManagerString *curString = &this->strings[0];
@@ -379,7 +379,7 @@ void AsciiManager::OnDrawLowPrioImpl()
     }
 }
 
-void AsciiManager::CreateScorePopup(D3DXVECTOR3 *position, i32 number, D3DCOLOR color)
+void AsciiManager::CreateScorePopup(Float3 *position, i32 number, D3DCOLOR color)
 {
     AsciiManagerPopup *popup;
     int characterCount;
@@ -422,7 +422,7 @@ void AsciiManager::CreateScorePopup(D3DXVECTOR3 *position, i32 number, D3DCOLOR 
     this->nextScorePopupIndex++;
 }
 
-void AsciiManager::CreatePlayerPointPopup(D3DXVECTOR3 *position, i32 number, D3DCOLOR color)
+void AsciiManager::CreatePlayerPointPopup(Float3 *position, i32 number, D3DCOLOR color)
 {
     AsciiManagerPopup *popup;
     int characterCount;
@@ -465,7 +465,7 @@ void AsciiManager::CreatePlayerPointPopup(D3DXVECTOR3 *position, i32 number, D3D
     this->nextPlayerPointPopupIndex++;
 }
 
-void AsciiManager::CreateTimePopup(D3DXVECTOR3 *position, i32 number, i32 param3, D3DCOLOR color)
+void AsciiManager::CreateTimePopup(Float3 *position, i32 number, i32 param3, D3DCOLOR color)
 {
     AsciiManagerPopup *popup;
     int characterCount;
@@ -521,7 +521,7 @@ void AsciiManager::CreateTimePopup(D3DXVECTOR3 *position, i32 number, i32 param3
     this->nextTimePopupIndex++;
 }
 
-void AsciiManager::CreateFamiliarPopup(D3DXVECTOR3 *position, i32 number, i32 param3, D3DCOLOR color)
+void AsciiManager::CreateFamiliarPopup(Float3 *position, i32 number, i32 param3, D3DCOLOR color)
 {
     AsciiManagerPopup *popup;
     int characterCount;
@@ -607,7 +607,7 @@ void AsciiManager::OnDrawHighPrioImpl()
 }
 
 // STUB: th08 0x405e10
-void AsciiManager::DrawPercentage(D3DXVECTOR3 *position, i32 percentage, D3DCOLOR color)
+void AsciiManager::DrawPercentage(Float3 *position, i32 percentage, D3DCOLOR color)
 {
 }
 

--- a/src/AsciiManager.hpp
+++ b/src/AsciiManager.hpp
@@ -47,7 +47,7 @@ C_ASSERT(sizeof(RetryMenu) == 0x1284);
 struct AsciiManagerString
 {
     char text[64];
-    D3DXVECTOR3 position;
+    Float3 position;
     D3DCOLOR color;
     f32 scaleX;
     f32 scaleY;
@@ -60,7 +60,7 @@ C_ASSERT(sizeof(AsciiManagerString) == 0x60);
 struct AsciiManagerPopup
 {
     char text[12];
-    D3DXVECTOR3 position;
+    Float3 position;
     D3DCOLOR color;
     ZunTimer timer;
     f32 scaleX;
@@ -83,16 +83,16 @@ struct AsciiManager
     static ZunResult AddedCallback(AsciiManager *mgr);
     static ZunResult DeletedCallback(AsciiManager *mgr);
     static void CutChain();
-    void AddString(D3DXVECTOR3 *position, const char *string);
-    void AddFormatText(D3DXVECTOR3 *position, const char *fmt, ...);
-    int AddFormatText2(D3DXVECTOR3 *position, const char *fmt, ...);
+    void AddString(Float3 *position, const char *string);
+    void AddFormatText(Float3 *position, const char *fmt, ...);
+    int AddFormatText2(Float3 *position, const char *fmt, ...);
     void OnDrawLowPrioImpl();
-    void CreateScorePopup(D3DXVECTOR3 *position, i32 number, D3DCOLOR color);
-    void CreatePlayerPointPopup(D3DXVECTOR3 *position, i32 number, D3DCOLOR color);
-    void CreateTimePopup(D3DXVECTOR3 *position, i32 number, i32 param3, D3DCOLOR color);
-    void CreateFamiliarPopup(D3DXVECTOR3 *position, i32 number, i32 param3, D3DCOLOR color);
+    void CreateScorePopup(Float3 *position, i32 number, D3DCOLOR color);
+    void CreatePlayerPointPopup(Float3 *position, i32 number, D3DCOLOR color);
+    void CreateTimePopup(Float3 *position, i32 number, i32 param3, D3DCOLOR color);
+    void CreateFamiliarPopup(Float3 *position, i32 number, i32 param3, D3DCOLOR color);
     void OnDrawHighPrioImpl();
-    void DrawPercentage(D3DXVECTOR3 *position, i32 percentage, D3DCOLOR color);
+    void DrawPercentage(Float3 *position, i32 percentage, D3DCOLOR color);
     void UpdateVms();
     void SetGaugeInterrupt(i32 interrupt);
     i32 GetGaugeInterrupt();

--- a/src/GameManager.hpp
+++ b/src/GameManager.hpp
@@ -257,10 +257,10 @@ struct GameManager
     u32 unk3ddcc;
     u16 unk3DDD0;
     u16 unk3DDD2;
-    D3DXVECTOR2 arcadeRegionTopLeftPos;
-    D3DXVECTOR2 arcadeRegionSize;
-    D3DXVECTOR2 playerMovementTopLeftPos;
-    D3DXVECTOR2 playerMovementAreaSize;
+    Float2 arcadeRegionTopLeftPos;
+    Float2 arcadeRegionSize;
+    Float2 playerMovementTopLeftPos;
+    Float2 playerMovementAreaSize;
     f32 antiTamperExpectedValue;
     i16 youkaiGaugeHumanLimit;
     i16 youkaiGaugeYoukaiLimit;

--- a/src/Global.cpp
+++ b/src/Global.cpp
@@ -1236,7 +1236,7 @@ f32 AddNormalizeAngle(f32 a, f32 b)
 }
 
 #pragma var_order(sinOut, cosOut)
-void Rotate(D3DXVECTOR3 *outVector, D3DXVECTOR3 *point, f32 angle)
+void Rotate(Float3 *outVector, Float3 *point, f32 angle)
 {
     f32 sinOut = sinf(angle);
     f32 cosOut = cosf(angle);

--- a/src/Global.hpp
+++ b/src/Global.hpp
@@ -357,7 +357,74 @@ struct ZunGlobals
 
 C_ASSERT(sizeof(ZunGlobals) == 0xe4);
 
-struct ZunVec2
+/* ZUN name: FVector */
+struct Float3
+{
+    Float3()
+    {
+    }
+
+    Float3(float x, float y, float z)
+    {
+        this->x = x;
+        this->y = y;
+        this->z = z;
+    }
+
+    void FromAngleMagnitude(float angle, float magnitude)
+    {
+        __asm
+        {
+            mov eax, this
+            fld angle
+            fsincos
+            fmul [magnitude]
+            fstp [eax]          /* this->x */
+            fmul [magnitude]
+            fstp [eax + 4]      /* this->y */
+        }
+    }
+
+    void FromRotatedVec2(float angle, float vecX, float vecY)
+    {
+        __asm
+        {
+            mov eax, this
+            fld angle
+            fsincos
+            fmul [vecX]
+            fstp [eax]          /* this->x */
+            fmul [vecY]
+            fstp [eax + 4]      /* this->y */
+        }
+    }
+
+    Float3 *operator += (const Float3 &other)
+    {
+        this->x += other.x;
+        this->y += other.y;
+        this->z += other.z;
+
+        return this;
+    }
+
+    Float3 *operator -= (const Float3 &other)
+    {
+        this->x -= other.x;
+        this->y -= other.y;
+        this->z -= other.z;
+
+        return this;
+    }
+
+
+    float x;
+    float y;
+    float z;
+};
+
+/* ZUN name: FVector2 */
+struct Float2
 {
     float x;
     float y;
@@ -372,7 +439,7 @@ struct ZunRect
 };
 
 f32 AddNormalizeAngle(f32 a, f32 b);
-void Rotate(D3DXVECTOR3 *outVector, D3DXVECTOR3 *point, f32 angle);
+void Rotate(Float3 *outVector, Float3 *point, f32 angle);
 
 DIFFABLE_EXTERN(Rng, g_Rng);
 DIFFABLE_EXTERN(u16, g_CurFrameInput);

--- a/src/Global.hpp
+++ b/src/Global.hpp
@@ -379,9 +379,9 @@ struct Float3
             fld angle
             fsincos
             fmul [magnitude]
-            fstp [eax]          /* this->x */
+            fstp [eax] /* this->x */
             fmul [magnitude]
-            fstp [eax + 4]      /* this->y */
+            fstp [eax + 4] /* this->y */
         }
     }
 
@@ -393,13 +393,13 @@ struct Float3
             fld angle
             fsincos
             fmul [vecX]
-            fstp [eax]          /* this->x */
+            fstp [eax] /* this->x */
             fmul [vecY]
-            fstp [eax + 4]      /* this->y */
+            fstp [eax + 4] /* this->y */
         }
     }
 
-    Float3 *operator += (const Float3 &other)
+    Float3 *operator+=(const Float3 &other)
     {
         this->x += other.x;
         this->y += other.y;
@@ -408,7 +408,7 @@ struct Float3
         return this;
     }
 
-    Float3 *operator -= (const Float3 &other)
+    Float3 *operator-=(const Float3 &other)
     {
         this->x -= other.x;
         this->y -= other.y;
@@ -416,7 +416,6 @@ struct Float3
 
         return this;
     }
-
 
     float x;
     float y;

--- a/src/ItemManager.cpp
+++ b/src/ItemManager.cpp
@@ -9,7 +9,7 @@ namespace th08
 DIFFABLE_STATIC(ItemManager, g_ItemManager);
 
 #pragma var_order(i, item)
-Item *ItemManager::SpawnItem(D3DXVECTOR3 *position, ItemType itemType, i32 state)
+Item *ItemManager::SpawnItem(Float3 *position, ItemType itemType, i32 state)
 {
     i32 i;
     Item *item = &this->items[this->nextIndex];

--- a/src/ItemManager.hpp
+++ b/src/ItemManager.hpp
@@ -35,9 +35,9 @@ struct Item
 {
     AnmVm sprite;
 
-    D3DXVECTOR3 currentPosition;
-    D3DXVECTOR3 startPositionOrVelocity;
-    D3DXVECTOR3 targetPosition;
+    Float3 currentPosition;
+    Float3 startPositionOrVelocity;
+    Float3 targetPosition;
 
     ZunTimer timer;
 
@@ -72,7 +72,7 @@ struct ItemManager
     Item itemListHead;
     Item *itemListTail;
 
-    Item *SpawnItem(D3DXVECTOR3 *position, ItemType itemType, int state);
+    Item *SpawnItem(Float3 *position, ItemType itemType, int state);
     static void UpdatePointItemExtendThreshold();
     void OnUpdate();
     void AutoCollectAllItems();

--- a/src/MusicRoom.cpp
+++ b/src/MusicRoom.cpp
@@ -214,7 +214,7 @@ i32 MusicRoom::ProcessInput()
     {
         g_Supervisor.curState = SupervisorState_TitleScreen;
 
-        g_Supervisor.SetupLoadingVmsAndInitCapture(&D3DXVECTOR3(500.0, 440.0f, 0.0f));
+        g_Supervisor.SetupLoadingVmsAndInitCapture(&Float3(500.0, 440.0f, 0.0f));
 
         return 1;
     }
@@ -314,7 +314,7 @@ start:
 ChainCallbackResult MusicRoom::OnDraw(MusicRoom *musicRoom)
 {
     int i;
-    D3DXVECTOR3 position;
+    Float3 position;
     D3DCOLOR color;
     char arrowText[4];
 

--- a/src/Supervisor.cpp
+++ b/src/Supervisor.cpp
@@ -473,7 +473,7 @@ int Supervisor::AddedCallback(Supervisor *s)
     g_AnmManager->SetupVertexBuffer();
     TextHelper::CreateTextBuffer();
 
-    D3DXVECTOR3 position(500.0, 440.0f, 0.0f);
+    Float3 position(500.0, 440.0f, 0.0f);
 
     g_Supervisor.SetupLoadingVms(&position);
 
@@ -1334,7 +1334,7 @@ void Supervisor::ThreadClose()
     }
 }
 
-void Supervisor::SetupLoadingVms(D3DXVECTOR3 *position)
+void Supervisor::SetupLoadingVms(Float3 *position)
 {
     if (this->loadingVmsHaveBeenSetup == 0)
     {
@@ -1361,7 +1361,7 @@ void Supervisor::HideLoadingVms(void)
     }
 }
 
-void Supervisor::SetupLoadingVmsAndInitCapture(D3DXVECTOR3 *position)
+void Supervisor::SetupLoadingVmsAndInitCapture(Float3 *position)
 {
     if (this->loadingVmsHaveBeenSetup == 0)
     {

--- a/src/Supervisor.hpp
+++ b/src/Supervisor.hpp
@@ -144,9 +144,9 @@ struct Supervisor
     ZunResult FadeOutMusic(float param_1);
 
     void ThreadClose();
-    void SetupLoadingVms(D3DXVECTOR3 *position);
+    void SetupLoadingVms(Float3 *position);
     void HideLoadingVms(void);
-    void SetupLoadingVmsAndInitCapture(D3DXVECTOR3 *position);
+    void SetupLoadingVmsAndInitCapture(Float3 *position);
     void StartEffect(i32 idx);
     void InitializeCriticalSections();
     void DeleteCriticalSections();

--- a/src/TitleScreen.cpp
+++ b/src/TitleScreen.cpp
@@ -171,7 +171,7 @@ DIFFABLE_STATIC_ASSIGN(const char *, g_FullWidthDigits[]) = {
     TH_TITLE_FULLWIDTH_DIGIT_8, TH_TITLE_FULLWIDTH_DIGIT_9,
 };
 
-void DrawPieChart(D3DXVECTOR3 *position, D3DCOLOR color, float param_3, float param_4);
+void DrawPieChart(Float3 *position, D3DCOLOR color, float param_3, float param_4);
 
 ChainCallbackResult TitleScreen::OnUpdate(TitleScreen *titleScreen)
 {
@@ -1935,7 +1935,7 @@ ChainCallbackResult TitleScreen::OnUpdateSpellStageSelect()
             }
 
             this->resultTextAnm->InitializeAndSetSprite(&this->spellCardNameVms[0], 2);
-            this->spellCardNameVms[0].pos = D3DXVECTOR3(0, 0, 0);
+            this->spellCardNameVms[0].pos = Float3(0, 0, 0);
             this->spellCardNameVms[0].prefix.anchor = 3;
             this->spellCardNameVms[0].fontWidth = 15;
             this->spellCardNameVms[0].fontHeight = 15;
@@ -1946,7 +1946,7 @@ ChainCallbackResult TitleScreen::OnUpdateSpellStageSelect()
             g_AnmManager->DrawTextLeft(&this->spellCardNameVms[0], 0xffffff, 0, TH_TITLE_SPELL_STAGE_INFO);
 
             this->resultTextAnm->InitializeAndSetSprite(&this->spellCardNameVms[1], 3);
-            this->spellCardNameVms[1].pos = D3DXVECTOR3(0, 0, 0);
+            this->spellCardNameVms[1].pos = Float3(0, 0, 0);
             this->spellCardNameVms[1].prefix.anchor = 3;
             this->spellCardNameVms[1].fontWidth = 15;
             this->spellCardNameVms[1].fontHeight = 15;
@@ -2139,7 +2139,7 @@ ChainCallbackResult TitleScreen::OnUpdateSpellCardSelect()
                                                                      TITLE_SPELL_CARD_SPELLCARDS_PER_PAGE];
 
                 this->resultTextAnm->InitializeAndSetSprite(&this->spellCardNameVms[i], i + 2);
-                this->spellCardNameVms[i].pos = D3DXVECTOR3(0, 0, 0);
+                this->spellCardNameVms[i].pos = Float3(0, 0, 0);
                 this->spellCardNameVms[i].prefix.anchor = 3;
                 /* Copy paste mistake? */
                 this->spellCardNameVms[0].fontWidth = 15;
@@ -2174,7 +2174,7 @@ ChainCallbackResult TitleScreen::OnUpdateSpellCardSelect()
 
             i = TITLE_SPELL_CARD_SPELLCARDS_PER_PAGE;
             this->resultTextAnm->InitializeAndSetSprite(&this->spellCardNameVms[i], i + 2);
-            this->spellCardNameVms[i].pos = D3DXVECTOR3(0, 0, 0);
+            this->spellCardNameVms[i].pos = Float3(0, 0, 0);
             this->spellCardNameVms[i].prefix.anchor = 3;
             this->spellCardNameVms[i].fontWidth = 15;
             this->spellCardNameVms[i].fontHeight = 15;
@@ -2197,11 +2197,11 @@ ChainCallbackResult TitleScreen::OnUpdateSpellCardSelect()
 
                 if (i < 4)
                 {
-                    this->spellCardInfoVms[i].pos = D3DXVECTOR3(64.0f, (i * 16) + 344.0f, 0.0f);
+                    this->spellCardInfoVms[i].pos = Float3(64.0f, (i * 16) + 344.0f, 0.0f);
                 }
                 else
                 {
-                    this->spellCardInfoVms[i].pos = D3DXVECTOR3(64.0f, (i * 16) + 344.0f + 8.0f, 0.0f);
+                    this->spellCardInfoVms[i].pos = Float3(64.0f, (i * 16) + 344.0f + 8.0f, 0.0f);
                 }
 
                 this->spellCardInfoVms[i].prefix.anchor = 3;
@@ -2279,7 +2279,7 @@ ChainCallbackResult TitleScreen::OnUpdateSpellCardSelect()
                 }
 
                 this->resultTextAnm->InitializeAndSetSprite(&this->spellCardNameVms[i2], i2 + 2);
-                this->spellCardNameVms[i2].pos = D3DXVECTOR3(0, 0, 0);
+                this->spellCardNameVms[i2].pos = Float3(0, 0, 0);
                 this->spellCardNameVms[i2].prefix.anchor = 3;
                 /* Similar copy paste mistake as before? */
                 this->spellCardInfoVms[0].fontWidth = 15;
@@ -2453,7 +2453,7 @@ ChainCallbackResult TitleScreen::DrawReplayMenu()
 #pragma var_order(vm, i, clearInfo, position)
 ChainCallbackResult TitleScreen::DrawPracticeStageSelect()
 {
-    D3DXVECTOR3 position;
+    Float3 position;
     u16 clearInfo;
     i32 i;
     AnmVm *vm;
@@ -2537,8 +2537,8 @@ ChainCallbackResult TitleScreen::DrawSpellStageSelect()
     i32 i;
     i32 spellCardIdx;
     i32 spellCardNumber;
-    D3DXVECTOR3 position;
-    D3DXVECTOR3 pieChartPosition;
+    Float3 position;
+    Float3 pieChartPosition;
 
     totalCapturesSpellPracticePerShot = 0;
     totalCapturesSpellPractice = 0;
@@ -2764,10 +2764,10 @@ ChainCallbackResult TitleScreen::DrawSpellStageSelect()
 
 /* Is matching except for missing stack space. */
 #pragma var_order(center, vm, vertices, i, angle)
-void DrawPieChart(D3DXVECTOR3 *position, D3DCOLOR color, float param_3, float param_4)
+void DrawPieChart(Float3 *position, D3DCOLOR color, float param_3, float param_4)
 {
     VertexDiffuseXyzrhw vertices[64];
-    D3DXVECTOR3 center;
+    Float3 center;
     AnmVm vm;
     float angle;
     i32 i;
@@ -2807,12 +2807,12 @@ ChainCallbackResult TitleScreen::DrawSpellCardSelect()
     i32 i;
     i32 spellCardNumber;
     u16 clearInfo;
-    D3DXVECTOR3 position;
+    Float3 position;
 
     g_AsciiManager.SetColor(0xffffffff);
     g_AsciiManager.SetIsSelected(FALSE);
 
-    position = D3DXVECTOR3(16.0f, 78.0f, 0.0f);
+    position = Float3(16.0f, 78.0f, 0.0f);
 
     clearInfo = g_GameManager.clrdData[g_GameManager.shotType]
                     .difficultiesClearedWithRetries[g_Supervisor.cfg.defaultDifficulty];
@@ -3034,7 +3034,7 @@ ChainCallbackResult TitleScreen::DrawCompletionStatusText()
 #pragma var_order(i, vm, position)
 ChainCallbackResult TitleScreen::OnDraw(TitleScreen *titleScreen)
 {
-    D3DXVECTOR3 position;
+    Float3 position;
     AnmVm *vm;
     int i;
 
@@ -3189,7 +3189,7 @@ ZunResult TitleScreen::ActualAddedCallback()
     g_GameManager.flags.isPracticeMode = FALSE;
     g_GameManager.flags.isSpellPractice = FALSE;
 
-    D3DXVECTOR3 loadingVmsPosition(500.0f, 440.0f, 0.0f);
+    Float3 loadingVmsPosition(500.0f, 440.0f, 0.0f);
 
     if (g_Supervisor.wantedState2 == SupervisorState_GameManager)
     {
@@ -3247,11 +3247,11 @@ void TitleScreen::TitleSetupThread(TitleScreen *titleScreen)
 
         if (i <= 4)
         {
-            g_TitleScreen->spellCardInfoVms[i].pos = D3DXVECTOR3(64.0f, (i * 16.0f) + 352.0f, 0.0f);
+            g_TitleScreen->spellCardInfoVms[i].pos = Float3(64.0f, (i * 16.0f) + 352.0f, 0.0f);
         }
         else
         {
-            g_TitleScreen->spellCardInfoVms[i].pos = D3DXVECTOR3(64.0f, (i * 16.0f) + 352.0f + 10.0f, 0.0f);
+            g_TitleScreen->spellCardInfoVms[i].pos = Float3(64.0f, (i * 16.0f) + 352.0f + 10.0f, 0.0f);
         }
 
         g_TitleScreen->spellCardInfoVms[i].prefix.anchor = 3;


### PR DESCRIPTION
Due to some oddities, such as "D3DXVECTOR2" having no constructor, and what is named "sincosmul" in the th06 decompilation being a member function of "D3DXVECTOR3", this is enough evidence to suggest that Float3 (aka FVector) and its counterpart, which are ZUN's custom vector types, that are in the modern Touhou games, also exist in IN, and most likely also in EoSD.